### PR TITLE
GitHub Actions: use JDK11 on Windows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,9 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
+        if: matrix.platform != 'windows-latest'
         with:
           distribution: temurin
           java-version: 17
+      # Windows で JDK 11 の選択に失敗することがあるため、Gradle を JVM 11 で実行する
+      # No matching toolchains found for requested specification: {languageVersion=11, vendor=any, implementation=vendor-specific}.
+      - uses: actions/setup-java@v3
+        if: matrix.platform == 'windows-latest'
+        with:
+          distribution: temurin
+          java-version: 11
       - uses: ./.github/actions/gradle-cache
       - name: JVM Build
         run: |


### PR DESCRIPTION
Gradle が JDK 選択に失敗することがあるため、JVM 11 で Gradle を実行する。
JDK 選択に成功するときと失敗するときがあるが再現手順は不明。

> No matching toolchains found for requested specification: {languageVersion=11, vendor=any, implementation=vendor-specific}.