### PR TITLE
jvmToolchain 11

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,17 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
-        if: matrix.platform != 'windows-latest'
         with:
           distribution: temurin
           java-version: 17
-      # Windows で JDK 11 の選択に失敗することがあるため、Gradle を JVM 11 で実行する
-      # No matching toolchains found for requested specification: {languageVersion=11, vendor=any, implementation=vendor-specific}.
-      - uses: actions/setup-java@v3
-        if: matrix.platform == 'windows-latest'
-        with:
-          distribution: temurin
-          java-version: 11
       - uses: ./.github/actions/gradle-cache
       - name: JVM Build
         run: |

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -23,3 +23,6 @@ gradlePlugin {
         }
     }
 }
+kotlin {
+    jvmToolchain(11)
+}

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,12 +1,10 @@
 plugins {
     `kotlin-dsl`
 }
-
 dependencies {
     implementation(libs.gradle.android)
-    implementation(libs.gradle.multiplatform)
+    implementation(libs.gradle.kotlin)
 }
-
 gradlePlugin {
     plugins {
         register("kotlin.multiplatform") {

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -17,4 +17,7 @@ dependencyResolutionManagement {
         }
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version ("0.5.0")
+}
 rootProject.name = "build-logic"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ gradle-android-target-sdk = "33"
 gradle-android-min-sdk = "21"
 
 [libraries]
-gradle-multiplatform = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 gradle-android = { module = "com.android.tools.build:gradle", version.ref = "gradle-android" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
* JVM 17 で実行する
* JVM 17 でも build-logic が実行できるようにする