### PR TITLE
CI: migrate Maven Central Publishing Portal API

### DIFF
--- a/.github/workflows/deploy_mavencentral_staging.yml
+++ b/.github/workflows/deploy_mavencentral_staging.yml
@@ -16,6 +16,10 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: ./.github/actions/gradle-cache
+      - name: Set Staging version
+        run: |
+          sed -i "" -E "s/^kfswatch = \"(.*)\"$/kfswatch = \"\\1-pr${{ github.event.pull_request.number }}.${{ github.run_number }}.${{ github.run_attempt }}\"/g" gradle/libs.versions.toml
+          grep "^kfswatch" gradle/libs.versions.toml
       - name: Deploy to Maven Central
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,11 +110,10 @@ subprojects {
 nexusPublishing {
     repositories {
         sonatype {
-            // io.github.irgaly staging profile
-            stagingProfileId = "6c098027ed608f"
-            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
+            stagingProfileId = libs.versions.kfswatch.get()
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
             snapshotRepositoryUrl =
-                uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }


### PR DESCRIPTION
migrate to Maven Central Publishing Portal API

* https://central.sonatype.org/pages/ossrh-eol/

use OSSRH Staging API

* https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/