### PR TITLE
Fix: SensitivityWatchEventModifier crash on Linux JVM

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: ./.github/actions/gradle-cache
       - name: JVM Build
         run: |

--- a/.github/workflows/deploy_mavencentral_release.yml
+++ b/.github/workflows/deploy_mavencentral_release.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: ./.github/actions/gradle-cache
       - name: Deploy to Maven Central
         env:

--- a/.github/workflows/deploy_mavencentral_staging.yml
+++ b/.github/workflows/deploy_mavencentral_staging.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: ./.github/actions/gradle-cache
       - name: Set Staging version
         run: |

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -22,5 +22,5 @@ gradlePlugin {
     }
 }
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ subprojects {
     }
     pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
         extensions.configure<KotlinProjectExtension> {
-            jvmToolchain(17)
+            jvmToolchain(21)
         }
         extensions.configure<KotlinMultiplatformExtension> {
             sourceSets {

--- a/sample/android/build.gradle.kts
+++ b/sample/android/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 dependencies {


### PR DESCRIPTION
* #138

fix crash on Linux JVM.
see details #138 

* [x] use JVM 21 on CI
* [x] use JVM 21 for Gradle
* [x] only use SensitivityWatchEventModifier when macOS and JVM is older than 19