### PR TITLE
update AGP 9.0.0, migrate Android Multiplatform Library Plugin

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Android Build
         if: contains(matrix.platform, 'ubuntu')
         run: |
-          ./gradlew :kfswatch:packageDebugAndroidTest
+          ./gradlew :kfswatch:packageAndroidDeviceTest
       - name: Linux Build
         if: contains(matrix.platform, 'ubuntu')
         run: |
@@ -69,8 +69,8 @@ jobs:
         with:
           api-level: 29
           script: |
-            #./gradlew :kfswatch:pixel6GroupDebugAndroidTest
-            ./gradlew :kfswatch:connectedDebugAndroidTest
+            #./gradlew :kfswatch:pixel6GroupAndroidDeviceTest
+            ./gradlew :kfswatch:connectedAndroidDeviceTest
       - name: Linux Test
         if: contains(matrix.platform, 'ubuntu')
         run: |

--- a/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/AndroidApplicationPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/AndroidApplicationPlugin.kt
@@ -7,8 +7,7 @@ class AndroidApplicationPlugin: Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                apply("com.android.application")
-                apply("org.jetbrains.kotlin.android")
+                apply(libs.pluginId("android-application"))
             }
             configureAndroid()
         }

--- a/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/AndroidLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/AndroidLibraryPlugin.kt
@@ -7,9 +7,8 @@ class AndroidLibraryPlugin: Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                apply("com.android.library")
+                apply(libs.pluginId("android-library"))
             }
-            configureAndroid()
             configureAndroidLibrary()
         }
     }

--- a/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
+++ b/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
@@ -1,9 +1,7 @@
 package io.github.irgaly.buildlogic
 
 import com.android.build.api.dsl.ApplicationExtension
-import com.android.build.api.dsl.CommonExtension
-import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
@@ -18,20 +16,14 @@ import java.io.ByteArrayOutputStream
 import javax.inject.Inject
 
 /**
- * android build 共通設定を適用する
+ * android application 共通設定を適用する
  */
 fun Project.configureAndroid() {
-    extensions.configure<BaseExtension> {
-        (this as CommonExtension<*, *, *, *, *, *>).apply {
-            compileSdk = libs.version("gradle-android-compile-sdk").toInt()
-            defaultConfig {
-                minSdk = libs.version("gradle-android-min-sdk").toInt()
-            }
-            if (this is ApplicationExtension) {
-                defaultConfig {
-                    targetSdk = libs.version("gradle-android-target-sdk").toInt()
-                }
-            }
+    extensions.configure<ApplicationExtension> {
+        compileSdk = libs.version("android-compile-sdk").toInt()
+        defaultConfig {
+            minSdk = libs.version("android-min-sdk").toInt()
+            targetSdk = libs.version("android-target-sdk").toInt()
         }
     }
 }
@@ -40,21 +32,19 @@ fun Project.configureAndroid() {
  * android library 共通設定を適用する
  */
 fun Project.configureAndroidLibrary() {
-    extensions.configure<LibraryExtension> {
-        buildFeatures {
-            buildConfig = false
-        }
-        packaging {
-            resources {
-                excludes.add("META-INF/AL2.0")
-                excludes.add("META-INF/LGPL2.1")
-                excludes.add("META-INF/licenses/ASM")
-                pickFirsts.add("win32-x86-64/attach_hotspot_windows.dll")
-                pickFirsts.add("win32-x86/attach_hotspot_windows.dll")
+    extensions.configure<KotlinMultiplatformExtension> {
+        extensions.configure<KotlinMultiplatformAndroidLibraryExtension> {
+            compileSdk = libs.version("android-compile-sdk").toInt()
+            minSdk = libs.version("android-min-sdk").toInt()
+            packaging {
+                resources {
+                    excludes.add("META-INF/AL2.0")
+                    excludes.add("META-INF/LGPL2.1")
+                    excludes.add("META-INF/licenses/ASM")
+                    pickFirsts.add("win32-x86-64/attach_hotspot_windows.dll")
+                    pickFirsts.add("win32-x86/attach_hotspot_windows.dll")
+                }
             }
-        }
-        sourceSets.configureEach {
-            java.srcDirs("src/$name/kotlin")
         }
     }
 }
@@ -106,12 +96,6 @@ fun Project.execute(vararg commands: String): String {
 @OptIn(ExperimentalKotlinGradlePluginApi::class)
 fun Project.configureMultiplatformLibrary() {
     extensions.configure<KotlinMultiplatformExtension> {
-        pluginManager.withPlugin("com.android.library") {
-            // Android AAR
-            androidTarget {
-                publishLibraryVariants("release", "debug")
-            }
-        }
         // Java jar
         jvm()
         // iOS

--- a/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/MultiplatformLibraryPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/MultiplatformLibraryPlugin.kt
@@ -7,9 +7,11 @@ class MultiplatformLibraryPlugin: Plugin<Project> {
     override fun apply(target: Project) {
         with(target) {
             with(pluginManager) {
-                apply("org.jetbrains.kotlin.multiplatform")
+                apply(libs.pluginId("kotlin-multiplatform"))
+                apply(libs.pluginId("android-library"))
             }
             configureMultiplatformLibrary()
+            configureAndroidLibrary()
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,9 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 
 plugins {
-    kotlin("multiplatform") version libs.versions.kotlin apply false
+    alias(libs.plugins.kotlin.multiplatform) apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotest) apply false
     alias(libs.plugins.buildlogic.multiplatform.library) apply false
@@ -36,7 +38,7 @@ subprojects {
                             implementation(libs.test.kotest.runner)
                         }
                     }
-                    findByName("androidInstrumentedTest")?.apply {
+                    findByName("androidDeviceTest")?.apply {
                         dependencies {
                             implementation(libs.bundles.test.android.devicetest)
                         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,3 @@
-android.useAndroidX=true
 org.gradle.jvmargs=-Xmx5g
 org.gradle.daemon.idletimeout=300000
 org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,10 @@ kfswatch = "1.4.0"
 kotlin = "2.3.20"
 kotlinx-coroutines = "1.10.1"
 kotest = "6.2.3"
-gradle-android = "8.13.0"
-gradle-android-compile-sdk = "34"
-gradle-android-target-sdk = "34"
-gradle-android-min-sdk = "26"
+gradle-android = "9.0.0"
+android-compile-sdk = "34"
+android-target-sdk = "34"
+android-min-sdk = "26"
 
 [libraries]
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -38,6 +38,9 @@ test-android-devicetest = [
 compose = ["compose-material3", "compose-uiTooling", "compose-activity"]
 
 [plugins]
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+android-application = { id = "com.android.application", version.ref = "gradle-android" }
+android-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "gradle-android" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version = "2.3.5" }
 kotest = { id = "io.kotest", version.ref = "kotest" }

--- a/kfswatch/build.gradle.kts
+++ b/kfswatch/build.gradle.kts
@@ -1,4 +1,3 @@
-import com.android.build.api.dsl.ManagedVirtualDevice
 import org.jetbrains.dokka.gradle.tasks.DokkaGeneratePublicationTask
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsPlugin.Companion.kotlinNodeJsEnvSpec
 
@@ -17,6 +16,33 @@ kotlin {
             linkerOpts("-lrpcrt4")
         }
     }
+    android {
+        namespace = "io.github.irgaly.kfswatch"
+        withDeviceTest {
+            managedDevices {
+                localDevices {
+                    val pixel6android13 by registering {
+                        device = "Pixel 6"
+                        apiLevel = 33 // Android 13
+                    }
+                    val pixel6android8 by registering {
+                        device = "Pixel 6"
+                        apiLevel = 27 // Android 8
+                    }
+                }
+                groups {
+                    register("pixel6") {
+                        targetDevices.addAll(
+                            listOf(
+                                localDevices["pixel6android13"],
+                                localDevices["pixel6android8"],
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
     applyDefaultHierarchyTemplate()
     sourceSets {
         commonMain {
@@ -29,7 +55,7 @@ kotlin {
                 implementation(projects.test)
             }
         }
-        val androidInstrumentedTest by getting {
+        val androidDeviceTest by getting {
             dependsOn(commonTest.get())
         }
     }
@@ -37,30 +63,6 @@ kotlin {
 
 kotlinNodeJsEnvSpec.apply {
     version = "24.9.0"
-}
-
-android {
-    namespace = "io.github.irgaly.kfswatch"
-    defaultConfig {
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-    testOptions {
-        managedDevices {
-            val pixel6android13 by devices.registering(ManagedVirtualDevice::class) {
-                device = "Pixel 6"
-                apiLevel = 33 // Android 13
-            }
-            val pixel6android8 by devices.registering(ManagedVirtualDevice::class) {
-                device = "Pixel 6"
-                apiLevel = 27 // Android 8
-            }
-            groups {
-                register("pixel6") {
-                    targetDevices.addAll(listOf(pixel6android13.get(), pixel6android8.get()))
-                }
-            }
-        }
-    }
 }
 
 val dokkaGeneratePublicationHtml by tasks.getting(DokkaGeneratePublicationTask::class)

--- a/test/build.gradle.kts
+++ b/test/build.gradle.kts
@@ -5,11 +5,10 @@ plugins {
     alias(libs.plugins.kotest)
 }
 
-android {
-    namespace = "io.github.irgaly.test"
-}
-
 kotlin {
+    android {
+        namespace = "io.github.irgaly.test"
+    }
     sourceSets {
         commonMain {
             dependencies {


### PR DESCRIPTION
* [x] update AGP9
* [x] use Android Multiplatform Library

~android-junitがAndroid Multiplatform Libraryに対応するのを待っている。~
~* mannodermaus/android-junit-framework/issues/406~

* → android-junit-frameworkを削除した #186