### PR TITLE
Gradle: remove kotlin.mpp.androidSourceSetLayoutVersion=2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,3 @@ org.gradle.jvmargs=-Xmx5g
 org.gradle.daemon.idletimeout=300000
 org.gradle.parallel=true
 org.gradle.caching=true
-kotlin.mpp.androidSourceSetLayoutVersion=2


### PR DESCRIPTION
* Kotlin 1.9.0からkotlin.mpp.androidSourceSetLayoutVersion=2がデフォルトとなっている