### PR TITLE
remove android-junit-framework, use JUnit4 on Android DeviceTest

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,11 @@ subprojects {
                             implementation(libs.test.kotest.runner)
                         }
                     }
+                    findByName("androidInstrumentedTest")?.apply {
+                        dependencies {
+                            implementation(libs.bundles.test.android.devicetest)
+                        }
+                    }
                 }
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ gradle-android = "8.13.0"
 gradle-android-compile-sdk = "34"
 gradle-android-target-sdk = "34"
 gradle-android-min-sdk = "26"
-junit5-android-test = "2.0.1"
 
 [libraries]
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -23,23 +22,21 @@ compose-activity = { module = "androidx.activity:activity-compose", version = "1
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-uiTooling = { module = "androidx.compose.ui:ui-tooling" }
 test-kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+test-kotest-runner-junit4 = { module = "io.kotest:kotest-runner-junit4", version.ref = "kotest" }
 test-kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 test-kotest-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 test-mockk = { module = "io.mockk:mockk", version = "1.14.4" }
 test-turbine = { module = "app.cash.turbine:turbine", version = "1.2.0" }
-test-android-junit5 = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.14.0" }
-test-android-junit5-core = { module = "de.mannodermaus.junit5:android-test-core", version.ref = "junit5-android-test" }
-test-android-junit5-runner = { module = "de.mannodermaus.junit5:android-test-runner", version.ref = "junit5-android-test" }
 test-android-runner = { module = "androidx.test:runner", version = "1.7.0" }
 korlibs-time = { module = "com.soywiz.korge:korlibs-time", version = "5.4.0" }
 kfswatch = { module = "io.github.irgaly.kfswatch:kfswatch", version.ref = "kfswatch" }
 
 [bundles]
 test-common = [
-    "kotlinx-coroutines-test", "test-kotest-engine",
-    "test-kotest-assertions", "test-turbine"]
-test-android-instrumented = [
-    "test-kotest-assertions", "test-android-junit5", "test-android-junit5-core", "test-android-runner",
+    "kotlinx-coroutines-test", "test-kotest-engine", "test-kotest-assertions", "test-turbine"
+]
+test-android-devicetest = [
+    "test-android-runner", "test-kotest-assertions", "test-kotest-runner-junit4",
     "kotlinx-coroutines-test", "test-turbine"
 ]
 compose = ["compose-material3", "compose-uiTooling", "compose-activity"]
@@ -53,4 +50,3 @@ buildlogic-android-application = { id = "build-logic.android.application" }
 buildlogic-android-library = { id = "build-logic.android.library" }
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-android-junit5 = { id = "de.mannodermaus.android-junit5", version = "2.0.1" }

--- a/kfswatch/build.gradle.kts
+++ b/kfswatch/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
     alias(libs.plugins.buildlogic.multiplatform.library)
     alias(libs.plugins.buildlogic.android.library)
     alias(libs.plugins.dokka)
-    alias(libs.plugins.android.junit5)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotest)
 }
@@ -32,15 +31,8 @@ kotlin {
         }
         val androidInstrumentedTest by getting {
             dependsOn(commonTest.get())
-            dependencies {
-                implementation(libs.bundles.test.android.instrumented)
-            }
         }
     }
-}
-
-dependencies {
-    androidTestRuntimeOnly(libs.test.android.junit5.runner)
 }
 
 kotlinNodeJsEnvSpec.apply {
@@ -51,8 +43,6 @@ android {
     namespace = "io.github.irgaly.kfswatch"
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        testInstrumentationRunnerArguments["runnerBuilder"] =
-            "de.mannodermaus.junit5.AndroidJUnit5Builder"
     }
     testOptions {
         managedDevices {

--- a/kfswatch/src/androidInstrumentedTest/kotlin/io/github/irgaly/kfswatch/AndroidTest.kt
+++ b/kfswatch/src/androidInstrumentedTest/kotlin/io/github/irgaly/kfswatch/AndroidTest.kt
@@ -1,25 +1,27 @@
 package io.github.irgaly.kfswatch
 
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
 import io.kotest.common.KotestInternal
 import io.kotest.core.spec.SpecRef
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
 import io.kotest.engine.test.TestResult
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
 
 class AndroidTest {
     @OptIn(KotestInternal::class)
     @Test
-    suspend fun commonTest() {
+    fun commonTest() = runTest {
         val listener = CollectingTestEngineListener()
         TestEngineLauncher()
             .withListener(listener)
             .withSpecRefs(SpecRef.Reference(KfswatchSpec::class))
             .execute()
-        listener.tests.map { entry ->
-            {
+        assertSoftly {
+            for (entry in listener.tests) {
                 val testCase = entry.key
                 val descriptor = testCase.descriptor.path().value
                 val cause = when (val value = entry.value) {
@@ -27,13 +29,13 @@ class AndroidTest {
                     is TestResult.Failure -> value.cause
                     else -> null
                 }
-                assertFalse(entry.value.isErrorOrFailure) {
+                withClue({
                     """$descriptor
                     |${cause?.stackTraceToString()}""".trimMargin()
+                }) {
+                    entry.value.isErrorOrFailure shouldBe false
                 }
             }
-        }.let {
-            assertAll(it)
         }
         println("Total ${listener.tests.size}, Failure ${listener.tests.count { it.value.isErrorOrFailure }}")
     }


### PR DESCRIPTION
* ref: #169

android-junit-frameworkが新しいKMP Android Library pluginに対応しないため、構成を変更する

* Android Device Test: android-junit-framework + JUnit5 + Kotest

↓

* Android Device Test: JUnit4 + Kotest